### PR TITLE
Ignore binary messages

### DIFF
--- a/accidentalbot.js
+++ b/accidentalbot.js
@@ -149,6 +149,10 @@ socketServer.on('connection', function(socket) {
     });
 
     socket.on('message', function (data, flags) {
+        if (flags.binary) {
+            console.log("ignoring binary message from "  + address);
+            return;
+        }
         var packet = JSON.parse(data);
         if (packet.operation === 'VOTE') {
             var matches = titles.findAll({id: packet['id']});


### PR DESCRIPTION
Ignore binary messages. The current behaviour is crash instead. :open_mouth: :frowning: 
