### PR TITLE
Use JavaScript strict mode, and a few few-character tweaks.

### DIFF
--- a/accidentalbot.js
+++ b/accidentalbot.js
@@ -1,9 +1,11 @@
+'use strict';
+
 var sugar = require('sugar');
 var irc = require('irc');
 var webSocket = require('ws');
 
 var channel = '#atp';
-var webAddress = 'http://www.caseyliss.com/showbot'
+var webAddress = 'http://www.caseyliss.com/showbot';
 
 var titles = [];
 var connections = [];
@@ -34,7 +36,7 @@ function handleNewSuggestion(from, message) {
     if (title.length > 0) {
         // Make sure this isn't a duplicate.
         if (titles.findAll({titleLower: title.toLowerCase()}).length === 0) {
-            var title = {
+            title = {
                 id: titles.length,
                 author: from,
                 title: title,
@@ -90,7 +92,7 @@ function handleNewLink(from, message) {
 function handleHelp(from) {
     client.say(from, 'Options:');
     client.say(from, '!s {title} - suggest a title.');
-    client.say(from, '!votes - get the three most highly voted titles.')
+    client.say(from, '!votes - get the three most highly voted titles.');
     client.say(from, '!link {URL} - suggest a link.');
     client.say(from, '!help - see this message.');
     client.say(from, 'To see titles/links, go to: ' + webAddress);

--- a/webclient/showbot.js
+++ b/webclient/showbot.js
@@ -1,4 +1,6 @@
-var Showbot = Showbot || {};
+'use strict';
+
+window.Showbot = window.Showbot || {};
 
 Showbot.Bot = (function ($) {
 
@@ -31,7 +33,7 @@ Showbot.Bot = (function ($) {
         var id = $(anchor).closest('tr').data('id');
         connection.send(JSON.stringify({operation: 'VOTE', id: id}));
         var voteSpan = $(anchor).parent().find('.votes');
-        voteSpan.html(new Number(voteSpan.html()) + 1);
+        voteSpan.html(Number(voteSpan.html()) + 1);
         $(anchor).remove();
         return false;
     }


### PR DESCRIPTION
(From #5.)

JavaScript strict mode is useful, if for nothing else than causing an assignment to an undefined/mis-typed variable to raise an error, rather than just creating a new variable under global scope and confusingly continuing in an invalid state. The only change necessary before enabling it was to explicitly attach `ShowBot` to `window`, rather than relying on the implicit global scope.

I also add a few missing semicolons, and a remove pointless use each of `var` and `new`.
