### PR TITLE
Update README to mention the need to set PROXIED on Heroku.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Work in progress.
 In the webclient/ directory there is a javascript and HTML file that
 show the general idea behind how a client would work.
 
-Note that for Heroku-based deployments, you will need to enable
-WebSockets for your app:
+Note that for Heroku-based deployments, you will need to enable WebSockets for
+your app, and set an environment variable to indicate that you're running
+behind a reverse proxy:
 
-`heroku labs:enable websockets -a APPNAME`
+    heroku labs:enable websockets -a APPNAME
+    heroku config:set PROXIED true -a APPNAME


### PR DESCRIPTION
(As required since #11.) This could also be easy to miss, and result in deployments with ineffective vote limiting.
