### PR TITLE
Memcached changeset (rebased)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ behind a reverse proxy:
 
     heroku labs:enable websockets -a APPNAME
     heroku config:set PROXIED true -a APPNAME
+
+To enable Memcached caching on Heroku, you will need to add the
+MemCachier addon for your app:
+
+    heroku addons:add memcachier -a APPNAME

--- a/accidentalbot.js
+++ b/accidentalbot.js
@@ -3,27 +3,114 @@
 var sugar = require('sugar');
 var irc = require('irc');
 var webSocket = require('ws');
+var crypto = require('crypto');
 
-var channel = '#atp';
-var webAddress = 'http://www.caseyliss.com/showbot';
-var TITLE_LIMIT = 75;
+var settings = {
+    irc: {
+        host:        'irc.freenode.net',
+        channelName: '#atp',
+        botName:     'accidentalbot'
+    },
+    cache: {
+        enabled: process.env.MEMCACHED_SERVERS || process.env.MEMCACHIER_SERVERS,
+        ttl:     60 * 60 * 24 * 2 // cache for two days
+    },
+    showbotLink:   'http://www.caseyliss.com/showbot',
+    titleLimit:    75,
+    linkLimit:     200,
+    startupDelay:  2000,
+    webSocketPort: Number(process.env.PORT || 5001),
+    isProxied:     process.env.PROXIED === 'true'
+};
 
-var titles = [];
-var connections = [];
-var links = [];
+// we'll persist these things
+var state = {
+    titles:  [],
+    votes:   [],
+    links:   [],
+    votesBy: []
+};
 
-function sendToAll(packet) {
-    connections.forEach(function (connection) {
-        try {
-            connection.send(JSON.stringify(packet));
-        } catch (e) {
-            console.log('sendToAll error: ' + e);
+
+/***************************************************
+ * MEMCACHE                                        *
+ ***************************************************/
+
+var cache;
+if (settings.cache.enabled) {
+    // will use defaults set in Heroku environment
+    // (Memcachier addon must be enabled for this)
+    var memjs = require('memjs');
+    cache = memjs.Client.create();
+
+    // part of a workaround for a production issue
+    // affecting memjs and Heroku/Memcachier
+    cache.get('-null-', function (err, value, key) {
+        console.log('Started up cache...');
+    });
+}
+
+function initStateFromCache(cb) {
+    var count = Object.keys(state).length;
+    Object.keys(state, function (k, v) {
+        state[k] = [];
+        if (!cache) {
+            cb('no cache', null, k);
+        } else {
+            cache.get(k, function (err, value, key) {
+                if (!err) {
+                    if (key !== null && value !== null) {
+                        try {
+                            state[k] = JSON.parse(value.toString());
+                        } catch (e) {
+                            // ruhroh
+                            console.log('Error parsing cache for ' + k + ' state:', e);
+                        }
+                    }
+                } else {
+                    console.log('Error fetching state key', k, 'from cache:', err);
+                }
+                if (cb) {
+                    cb(err, value, k);
+                }
+            });
         }
     });
 }
 
-function saveBackup() {
-    // TODO: Figure out what to do here.
+function updateState(thing, cb) {
+    if (cache) {
+        cache.set(thing, JSON.stringify(state[thing]), cb, settings.cache.ttl);
+    } else {
+        cb('no cache');
+    }
+}
+
+function startupCache(options) {
+    initStateFromCache(function (err, value, key) {
+        if (!err) {
+            if (key === 'titles') {
+                if (!err && state.titles.length) {
+                    console.log('loaded ' + state.titles.length + ' titles from cache...');
+                } else {
+                    console.log('no titles were found in cache');
+                }
+            }
+        }
+    });
+}
+
+
+/***************************************************
+ * IRC                                             *
+ ***************************************************/
+
+var client;
+
+function makeHash(str) {
+    var md5 = crypto.createHash('md5');
+    md5.update(str.toLowerCase());
+    return md5.digest('hex');
 }
 
 function handleNewSuggestion(from, message) {
@@ -32,75 +119,83 @@ function handleNewSuggestion(from, message) {
         title = RegExp.$1.compact();
     }
 
-    if (title.length > TITLE_LIMIT) {
-        client.say(from, 'That title is too long (over ' + TITLE_LIMIT +
+    if (title.length > settings.titleLimit) {
+        client.say(from, 'That title is too long (over ' + settings.titleLimit +
             ' characters); please try again.');
         title = '';
     }
     if (title.length > 0) {
-
-		var normalizedTitle = normalize(title);
-
         // Make sure this isn't a duplicate.
-        if (titles.findAll({normalized: normalizedTitle}).length === 0) {
-            title = {
-                id: titles.length,
+        var titleHash = makeHash(title);
+        if (state.titles.findAll({hash: titleHash}).length === 0) {
+            var id = state.titles.length;
+            var submission = {
+                id: id,
                 author: from,
                 title: title,
-                normalized: normalizedTitle,
-                votes: 0,
-                votesBy: [],
+                hash: titleHash,
                 time: new Date()
             };
-            titles.push(title);
-
-            sendToAll({operation: 'NEW', title: title});
+            state.titles[id] = submission;
+            updateState('titles', function (err) {
+                var data = Object.clone(submission);
+                data.votes = 0;
+                data.voted = false;
+                sendToAll({operation: 'NEW', title: data});
+            });
         } else {
-            //client.say(channel, 'Sorry, ' + from + ', your title is a duplicate. Please try another!');
             client.say(from, 'Sorry, your title is a duplicate. Please try another!');
         }
     }
 }
 
-function normalize(title) {
-	// Strip trailing periods from title
-	title = title.toLowerCase();
-	title = title.replace(/^[.\s]+|[.\s]+$/g, '');
-
-	return title;
-}
-
 function handleSendVotes(from, message) {
-    var titlesByVote = titles.sortBy(function (t) {
-        return t.votes;
+    var titlesByVote = state.titles.sortBy(function (t) {
+        return state.votes[t.id] || 0;
     }, true).to(3);
 
     client.say(from, 'Three most popular titles:');
-    for (var i = 0; i < titlesByVote.length; ++i) {
-        var votes = titlesByVote[i]['votes'];
-        client.say(from, titlesByVote[i]['votes'] + ' vote' + (votes != 1 ? 's' : '') +  ': " ' + titlesByVote[i].title + '"');
-    }
+    titlesByVote.each(function (title) {
+        var votes = state.votes[title.id] || 0;
+        client.say(from, votes + ' vote' +
+            (votes != 1 ? 's' : '') +  ': " ' + title.title + '"');
+    });
+}
+
+function looksLikeALink(link) {
+    // nothing too formal; just match for a sensible starting
+    // URL, domain-wise (and no auth), and weed out some of the
+    // problem characters in the path portion
+    return (link.match(/^https?:\/\/(?:[a-z0-9-]+\.)+(?:[a-z0-9-]+)(?::\d{2,4})?(?:\/|$)/) &&
+            !link.match(/[\\()[<>'" ]/)) ? true : false;
 }
 
 function handleNewLink(from, message) {
-    if (message.startsWith('!link')) {
-        message = message.substring(6);
-    } else if (message.startsWith('!l')) {
-        message = message.substring(3);
+    var link = '';
+    if (message.startsWith('!link ')) {
+        link = message.substring(6).trim();
+    } else if (message.startsWith('!l ')) {
+        link = message.substring(3).trim();
     }
 
-    if (message.startsWith('http')) {
-        var link = {
-            id: links.length,
+    if (link.length > settings.linkLimit) {
+        client.say(from, 'That link is too long (over ' + settings.linkLimit +
+            ' characters); please try again.');
+    } else if (looksLikeALink(link)) {
+        var id = state.links.length;
+        var submission = {
+            id: id,
             author: from,
-            link: message,
+            link: link,
             time: new Date()
         };
-        links.push(link);
+        state.links[id] = submission;
 
-        sendToAll({operation: 'NEWLINK', link: link});
+        updateState('links', function (err) {
+            sendToAll({operation: 'NEWLINK', link: submission});
+        });
     } else {
-        client.say(from, "That doesn't look like a link to me.");
+        client.say(from, 'That doesn\'t look like a link to me.');
     }
 }
 
@@ -110,41 +205,44 @@ function handleHelp(from) {
     client.say(from, '!votes - get the three most highly voted titles.');
     client.say(from, '!link {URL} - suggest a link.');
     client.say(from, '!help - see this message.');
-    client.say(from, 'To see titles/links, go to: ' + webAddress);
+    client.say(from, 'To see titles/links, go to: ' + settings.showbotLink);
 }
 
-var client = new irc.Client('irc.freenode.net', 'accidentalbot', {
-    channels: [channel]
-});
+function startupIrc(options) {
+    client = new irc.Client(options.host, options.botName, {
+        channels: [options.channelName]
+    });
 
-client.addListener('join', function (channel, nick, message) {
-    console.log('Joined channel ' + channel);
-    setInterval(saveBackup, 300000);
-});
+    client.addListener('join', function (channel, nick, message) {
+        console.log('Joined channel ' + channel);
+    });
 
-client.addListener('message', function (from, to, message) {
-    if (message.startsWith('!s')) {
-        handleNewSuggestion(from, message);
-    } else if (message.startsWith("!votes")) {
-        handleSendVotes(from, message);
-    } else if (message.startsWith('!l')) {
-        handleNewLink(from, message);
-    } else if (message.startsWith('!help')) {
-        handleHelp(from);
-    }
-});
+    client.addListener('message', function (from, to, message) {
+        if (message.startsWith('!s')) {
+            handleNewSuggestion(from, message);
+        } else if (message.startsWith('!votes')) {
+            handleSendVotes(from, message);
+        } else if (message.startsWith('!l')) {
+            handleNewLink(from, message);
+        } else if (message.startsWith('!help')) {
+            handleHelp(from);
+        }
+    });
 
-client.addListener('error', function (message) {
-    console.log('error: ', message);
-});
+    client.addListener('error', function (message) {
+        console.log('IRC error: ', message);
+    });
+}
+
 
 /***************************************************
  * WEB SOCKETS                                     *
  ***************************************************/
 
-var port = Number(process.env.PORT || 5001);
-var proxied = process.env.PROXIED === 'true';
-var socketServer = new webSocket.Server({port: port});
+// an array of active websocket connections
+var connections = [];
+
+var socketServer;
 
 // DOS protection - we disconnect any address which sends more than windowLimit
 // messages in a window of windowSize milliseconds.
@@ -178,13 +276,13 @@ function floodedBy(socket) {
     }
 
     if (recentMessages[address] > windowLimit) {
-        console.warn("Disconnecting flooding address: " + address);
+        console.warn('Disconnecting flooding address: ' + address);
         socket.terminate();
 
         for (var i = 0, l = connections.length; i < l; i++) {
             if (getRequestAddress(connections[i].upgradeReq) === address &&
                 connections[i] != socket) {
-                console.log("Disconnecting additional connection.");
+                console.log('Disconnecting additional connection.');
                 connections[i].terminate();
             }
         }
@@ -196,7 +294,7 @@ function floodedBy(socket) {
 }
 
 function getRequestAddress(request) {
-    if (proxied && 'x-forwarded-for' in request.headers) {
+    if (settings.isProxied && 'x-forwarded-for' in request.headers) {
         // This assumes that the X-Forwarded-For header is generated by a
         // trusted proxy such as Heroku. If not, a malicious user could take
         // advantage of this logic and use it to to spoof their IP.
@@ -208,77 +306,111 @@ function getRequestAddress(request) {
     }
 }
 
-socketServer.on('connection', function(socket) {
-    if (floodedBy(socket)) return;
-
-    connections.push(socket);
-    var address = getRequestAddress(socket.upgradeReq);
-    console.log('Client connected: ' + address);
-
-    // Instead of sending all of the information about current titles to the
-    // newly-connecting user, which would include the IP addresses of other
-    // users, we just send down the information they need.
-    var titlesWithVotes = titles.map(function (title) {
-        var isVoted = title.votesBy.some(function (testAddress) {
-            return testAddress === address;
-        });
-        var newTitle = {
-            id: title.id,
-            author: title.author,
-            title: title.title,
-            votes: title.votes,
-            voted: isVoted,
-            time: title.time
-        };
-        return newTitle;
-    });
-    socket.send(JSON.stringify({operation: 'REFRESH', titles: titlesWithVotes, links: links}));
-
-    socket.on('close', function () {
-        console.log('Client disconnected: ' + address);
-        connections.splice(connections.indexOf(socket), 1);
-    });
-
-    socket.on('error', function (reason, code) {
-      console.log('socket error: reason ' + reason + ', code ' + code);
-    });
-
-    socket.on('message', function (data, flags) {
-        if (floodedBy(socket)) return;
-
-        if (flags.binary) {
-            console.log("ignoring binary message from "  + address);
-            return;
-        }
-
-        var packet;
+function sendToAll(packet) {
+    connections.forEach(function (connection) {
         try {
-            packet = JSON.parse(data);
+            connection.send(JSON.stringify(packet));
         } catch (e) {
-            console.log('error: malformed JSON message (' + e + '): '+ data);
+            console.log('sendToAll error: ' + e);
+        }
+    });
+}
+
+function startupSocketServer(port) {
+    socketServer = new webSocket.Server({port: port});
+
+    socketServer.on('connection', function(socket) {
+        if (floodedBy(socket)) {
             return;
         }
 
-        if (packet.operation === 'VOTE') {
-            var matches = titles.findAll({id: packet['id']});
+        connections.push(socket);
+        var address = getRequestAddress(socket.upgradeReq);
+        console.log('Client connected: ' + address);
 
-            if (matches.length > 0) {
-                var upvoted = matches[0];
-                if (upvoted['votesBy'].any(address) === false) {
-                    upvoted['votes'] = Number(upvoted['votes']) + 1;
-                    upvoted['votesBy'].push(address);
-                    sendToAll({operation: 'VOTE', votes: upvoted['votes'], id: upvoted['id']});
-                    console.log('+1 for ' + upvoted['title'] + ' by ' + address);
-                } else {
-                    console.log('ignoring duplicate vote by ' + address + ' for ' + upvoted['title']);
-                }
-            } else {
-                console.log('no matches for id: ' + packet['id']);
+        socket.on('close', function () {
+            console.log('Client disconnected: ' + address);
+            connections.splice(connections.indexOf(socket), 1);
+        });
+
+        socket.on('error', function (reason, code) {
+            console.log('socket error: reason ' + reason + ', code ' + code);
+        });
+
+        socket.on('message', function (data, flags) {
+            if (floodedBy(socket)) return;
+
+            if (flags.binary) {
+                console.log('ignoring binary message from '  + address);
+                return;
             }
-        } else if (packet.operation === 'PING') {
-            socket.send(JSON.stringify({operation: 'PONG'}));
-        } else {
-            console.log("Don't know what to do with " + packet['operation']);
-        }
+
+            var packet;
+            try {
+                packet = JSON.parse(data);
+            } catch (e) {
+                console.log('error: malformed JSON message (' + e + '): '+ data);
+                return;
+            }
+
+            if (packet.operation === 'VOTE') {
+                state.titles.findAll({id: packet['id']}).each(function (upvoted) {
+                    var id = upvoted.id;
+                    if (!state.votesBy[id]) {
+                        state.votesBy[id] = {};
+                    }
+                    if (state.votesBy[id][address] !== true) {
+                        state.votes[id] = Number(state.votes[id] || 0) + 1;
+                        state.votesBy[id][address] = true;
+                        updateState('votes', function (err) {
+                            console.log('+1 for ' + upvoted['title'] + ' by ' + address);
+                            sendToAll({operation: 'VOTE', votes: state.votes[id], id: id});
+                        });
+                        updateState('votesBy');
+                    } else {
+                        console.log('ignoring duplicate vote by ' + address + ' for ' + upvoted['title']);
+                    }
+                });
+            } else if (packet.operation === 'PING') {
+                socket.send(JSON.stringify({operation: 'PONG'}));
+            } else {
+                console.log('Don\'t know what to do with ' + packet['operation']);
+            }
+        });
+
+        // Instead of sending all of the information about current titles to the
+        // newly-connecting user, which would include the IP addresses of other
+        // users, we just send down the information they need.
+        var titlesWithVotes = state.titles.map(function (title) {
+            var newTitle = {
+                id: title.id,
+                author: title.author,
+                title: title.title,
+                votes: state.votes[title.id] || 0,
+                voted: state.votesBy[title.id] && state.votesBy[title.id][address] === true,
+                time: title.time
+            };
+            return newTitle;
+        });
+        socket.send(JSON.stringify({operation: 'REFRESH', titles: titlesWithVotes, links: state.links}));
     });
-});
+}
+
+function start() {
+    console.log('Starting up ' + settings.irc.botName);
+    if (settings.cache.enabled) {
+        console.log('...checking cache for existing titles');
+        startupCache(settings.cache);
+    }
+    console.log('...connecting to IRC <' + settings.irc.host + '>');
+    startupIrc(settings.irc);
+    console.log('...listening for WebSocket connections on port', settings.webSocketPort);
+    startupSocketServer(settings.webSocketPort);
+    console.log('...ready!');
+}
+
+// Workaround a cold-start bug that seems to exist in memjs
+// by adding a delayed start for the Heroku app, we're able
+// to load existing titles, links, etc. from our cache.
+console.log('Waiting to start...');
+setTimeout(start, settings.startupDelay);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "irc": "^0.3.6",
     "sugar": "^1.4.1",
-    "ws": "^0.4.31"
+    "ws": "^0.4.31",
+    "memjs": "^0.8.4"
   },
   "repository": {
       "type": "git",

--- a/webclient/showbot.html
+++ b/webclient/showbot.html
@@ -5,8 +5,8 @@
         <script src="http://cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.3.0/handlebars.min.js"></script>
         <script src="showbot.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.6.0/moment.min.js"></script>
-		<script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-		<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css"></link>
+        <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+        <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css"></link>
     </head>
     <body class="container-fluid">
         <script id="titleRow" type="text/x-handlebars-template">


### PR DESCRIPTION
Includes a bit of refactoring to minimize the amount of data per title we cache, since all titles are cached under a single key. Even with a 1 MB limit per key, this will hold a lot of titles. Caching is automatically enabled if a `MEMCACHED_SERVERS` (or `MEMCACHIER_SERVERS`) environment variable is set. If caching is not enabled, the bot still works as it did before.

The list of IPs that voted for each title is stored in a separate key, again to minimize the amount of data placed in the titles data structure, but also to limit writes to the titles key, so we aren't updating the larger structure in Memcached for each vote. Similarly, vote counts are stored separately as well.

Finally, there is a bit of sanity checking done for submitted links (including an overall limit to the link length).

Hopefully, this squashed and rebased pull request is easier to review. In addition to simple persistence via cache, we should look at a proper key/value storage service or a real, honest-to-goodness database.
