### PR TITLE
title deduplication

### DIFF
--- a/accidentalbot.js
+++ b/accidentalbot.js
@@ -72,7 +72,7 @@ function handleNewSuggestion(from, message) {
 function normalize(title) {
 	// Strip trailing periods from title
 	title = title.toLowerCase();
-	title = title.replace(/^[.\s]+|[.\s]+$/g, '');
+	title = title.replace(/[^a-zA-Z0-9]+/g, '');
 
 	return title;
 }


### PR DESCRIPTION
this should greatly reduce noise by more aggressively reducing duplicate suggestions. it'll normalize a title by removing _any_ special character -- not only leading and trailing periods.