### PR TITLE
Open show note links in a new tab

### DIFF
--- a/webclient/showbot.js
+++ b/webclient/showbot.js
@@ -42,7 +42,7 @@ Showbot.Bot = (function ($) {
         var link = $(anchor).attr('href');
         var answer = confirm("Tread carefully; these links aren't checked for safety!\nWould you like to go to the following URL?\n\n" + link);
         if (answer) {
-            window.location = link;
+            window.open(link);
         }
         return false;
     }


### PR DESCRIPTION
Having to navigate back to the bot page after clicking on a link is a bit of a pain. This one-liner should fix it satisfactorily.